### PR TITLE
Report current version in / endpoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='Wayback-discover-diff',
-    version='0.1.2.2',
+    name='wayback-discover-diff',
+    version='0.1.2.3',
     description='Calculate wayback machine captures simhash',
     packages=find_packages(),
     zip_safe=False,
@@ -14,7 +14,6 @@ setup(
         'PyYAML',
         'Celery',
         'gunicorn',
-        'pytest',
         'xxhash',
         'lxml',
         'beautifulsoup4',

--- a/wayback_discover_diff/__init__.py
+++ b/wayback_discover_diff/__init__.py
@@ -1,5 +1,5 @@
 import os
-
+import pkg_resources
 from celery import (Celery, states)
 from celery.result import AsyncResult
 from flask import (Flask, request, jsonify, json)
@@ -37,6 +37,14 @@ CELERY.conf.task_default_queue = CFG['celery_queue_name']
 cors = CFG.get('cors')
 if cors:
     CORS(APP, origins=cors)
+
+
+@APP.route('/')
+def root():
+    """Return info on the current package version.
+    """
+    version = pkg_resources.require("wayback-discover-diff")[0].version
+    return "wayback-discover-diff service version: %s" % version
 
 
 @APP.route('/simhash')


### PR DESCRIPTION
Useful to know the current version of the program in production.

Remove `pytest` for setup requirements, its only necessary in dev
requirements.

Bump version.