### PR TITLE
When no simhash available return just empty dict

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -46,7 +46,7 @@ def test_no_entry():
     resp = client.get('/simhash?timestamp=20180000000000&url=nonexistingdomain.org')
     assert resp.status_code == 200
     data = json.loads(resp.data.decode('utf-8'))
-    assert data == dict(simhash='None')
+    assert data == {}
 
 # TODO must mock this
 # def test_start_task():
@@ -88,7 +88,7 @@ def test_task_no_snapshots():
     client = Client(APP, response_wrapper=BaseResponse)
     resp = client.get('/simhash?url=nonexistingdomain.org&year=1999')
     data = json.loads(resp.data.decode('utf-8'))
-    assert data == dict(simhash='None')
+    assert data == {}
 
 
 # TODO must mock this

--- a/wayback_discover_diff/web.py
+++ b/wayback_discover_diff/web.py
@@ -53,13 +53,13 @@ def simhash():
             snapshots_per_page = snapshots.get('number_per_page')
             results = year_simhash(APP.redis_db, url, year, page, snapshots_per_page)
             if not results:
-                results = {'simhash': 'None'}
+                results = {}
             return jsonify(results)
         else:
             # self._log.info('requesting redis db entry for %s %s', url, timestamp)
             results = timestamp_simhash(APP.redis_db, url, timestamp)
             if not results:
-                results = {'simhash': 'None'}
+                results = {}
             return jsonify(results)
     except ValueError:
         return jsonify({'status': 'error', 'info': 'year param must be numeric.'})


### PR DESCRIPTION
Do not return `{'simhash': 'None'}` when no simhash data are available, it is confusing to the clients.
Just return `{}`.

Update unit tests.