### PR TITLE
Disable custom hash function, fix b64 encoding bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='wayback-discover-diff',
-    version='0.1.6.6',
+    version='0.1.6.7',
     description='Calculate wayback machine captures simhash',
     packages=find_packages(),
     zip_safe=False,

--- a/wayback_discover_diff/conf.yml.example
+++ b/wayback_discover_diff/conf.yml.example
@@ -1,5 +1,5 @@
 simhash:
-    size: 128
+    size: 256
     expire_after: 86400
 
 redis_uri: "redis://localhost:6379/1"

--- a/wayback_discover_diff/feature_extraction_cli.py
+++ b/wayback_discover_diff/feature_extraction_cli.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+"""Extract and print features from target capture.
+Utility script useful to experiment and evaluate feature extraction.
+"""
+import pprint
+import sys
+import urllib3
+from wayback_discover_diff.discover import extract_html_features
+
+url = sys.argv[1]
+
+http = urllib3.PoolManager()
+res = http.request('GET', url)
+data = res.data.decode('utf-8')
+
+features = extract_html_features(data)
+pprint.pprint(features)


### PR DESCRIPTION
Custom hash function using `xxhash` returned always simhash with the
same size despite changing simhash size in conf. Default hash function
works well with that.

`struct.pack('L', simhash)` crashes when simhash is over a certain size.
Converted to use `str(simhash)`.encode('ascii')` instead.

Use `script.decompose()` instead of `script.extract()` because it
doesn't return anything. Its more efficient.

Change default simhash size to 256.

Add `feature_extraction_cli.py` to experiment with feature extraction.