### PR TITLE
use int.to_bytes to pack simhash value to bytes

### DIFF
--- a/wayback_discover_diff/discover.py
+++ b/wayback_discover_diff/discover.py
@@ -230,6 +230,6 @@ class Discover(Task):
             self._log.info('save simhash to Redis for timestamp %s urlkey %s',
                            ts, urlkey)
             self.redis_db.hset(urlkey, ts,
-                               pack_simhash_to_bytes(data))
+                               base64.b64encode(pack_simhash_to_bytes(data)))
         except RedisError as exc:
             self._log.error('cannot save simhash to Redis (%s)', exc)

--- a/wayback_discover_diff/discover.py
+++ b/wayback_discover_diff/discover.py
@@ -205,8 +205,9 @@ class Discover(Task):
                 for ts, simhash in final_results.items():
                     if simhash:
                         simhash_value = simhash.value
+                        size_in_bytes = (simhash_value.bit_length() + 7) // 8
                         pipe.hset(urlkey, ts,
-                                  base64.b64encode(simhash_value.to_bytes((simhash_value.bit_length() + 7) // 8)))
+                                  base64.b64encode(simhash_value.to_bytes(size_in_bytes, byteorder='little')))
                 pipe.expire(urlkey, self.simhash_expire)
                 pipe.execute()
                 pipe.reset()

--- a/wayback_discover_diff/discover.py
+++ b/wayback_discover_diff/discover.py
@@ -60,6 +60,12 @@ def calculate_simhash(features_dict, simhash_size):
     return Simhash(features_dict, simhash_size).value
 
 
+def pack_simhash_to_bytes(simhash):
+    simhash_value = simhash.value
+    size_in_bytes = (simhash_value.bit_length() + 7) // 8
+    return simhash_value.to_bytes(size_in_bytes, byteorder='little')
+
+
 class Discover(Task):
     """Custom Celery Task class.
     http://docs.celeryproject.org/en/latest/userguide/tasks.html#custom-task-classes
@@ -204,10 +210,8 @@ class Discover(Task):
                 pipe = self.redis_db.pipeline()
                 for ts, simhash in final_results.items():
                     if simhash:
-                        simhash_value = simhash.value
-                        size_in_bytes = (simhash_value.bit_length() + 7) // 8
                         pipe.hset(urlkey, ts,
-                                  base64.b64encode(simhash_value.to_bytes(size_in_bytes, byteorder='little')))
+                                  base64.b64encode(pack_simhash_to_bytes(simhash)))
                 pipe.expire(urlkey, self.simhash_expire)
                 pipe.execute()
                 pipe.reset()
@@ -226,6 +230,6 @@ class Discover(Task):
             self._log.info('save simhash to Redis for timestamp %s urlkey %s',
                            ts, urlkey)
             self.redis_db.hset(urlkey, ts,
-                               base64.b64encode(str(data).encode('ascii')))
+                               pack_simhash_to_bytes(data))
         except RedisError as exc:
             self._log.error('cannot save simhash to Redis (%s)', exc)

--- a/wayback_discover_diff/discover.py
+++ b/wayback_discover_diff/discover.py
@@ -204,8 +204,9 @@ class Discover(Task):
                 pipe = self.redis_db.pipeline()
                 for ts, simhash in final_results.items():
                     if simhash:
+                        simhash_value = simhash.value
                         pipe.hset(urlkey, ts,
-                                  base64.b64encode(str(simhash).encode('ascii')))
+                                  base64.b64encode(simhash_value.to_bytes((simhash_value.bit_length() + 7) // 8)))
                 pipe.expire(urlkey, self.simhash_expire)
                 pipe.execute()
                 pipe.reset()


### PR DESCRIPTION
The problem is that ```str(simhash)``` just converts instance of `Simhash` to the string and doesn't care about actual simhash value.
Something like ```<simhash.Simhash object at 0x7f4897cb1b70>```