### PR TITLE
Configurable logging by YAML conf

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='wayback-discover-diff',
-    version='0.1.6.11',
+    version='0.1.6.12',
     description='Calculate wayback machine captures simhash',
     packages=find_packages(),
     zip_safe=False,
@@ -13,7 +13,6 @@ setup(
         'urllib3',
         'PyYAML',
         'Celery',
-        'gunicorn',
         'lxml',
         'beautifulsoup4',
         'flask-cors',

--- a/wayback_discover_diff/application.py
+++ b/wayback_discover_diff/application.py
@@ -1,6 +1,6 @@
 """application.py -- top-level web application for wayback-discover-diff.
 """
-import logging
+import logging.config
 import os
 from celery import Celery
 from flask_cors import CORS
@@ -12,13 +12,9 @@ from wayback_discover_diff.discover import Discover
 CFG = load_config()
 
 # Init logging
-logfile = CFG['logfile']['name']
-loglevel = CFG['logfile']['level']
-logging.getLogger(__name__).setLevel(loglevel)
-logging.basicConfig(format='%(asctime)s %(name)s %(levelname)s %(message)s',
-                    handlers=[logging.FileHandler(logfile),
-                              logging.StreamHandler()]
-                    )
+logconf = CFG.get('logging')
+if logconf:
+    logging.config.dictConfig(logconf)
 
 # Init Celery app
 CELERY = Celery(config_source=CFG['celery'])

--- a/wayback_discover_diff/conf.yml.example
+++ b/wayback_discover_diff/conf.yml.example
@@ -18,10 +18,6 @@ celery:
     task_soft_time_limit: 7200
     worker_max_tasks_per_child: 100
 
-logfile:
-    name: "log.txt"
-    level: 20
-
 threads: 8
 
 snapshots:
@@ -31,3 +27,22 @@ snapshots:
 cors:
     ['http://localhost:3000',
     'http://localhost:3001']
+
+logging:
+  version: 1
+  disable_existing_loggers: false
+  handlers:
+    console: { class: logging.StreamHandler, formatter: default }
+  formatters:
+    default:
+      format: "%(asctime)s %(levelname)s %(thread)d %(name)s %(message)s"
+      datefmt: "%Y-%m-%d %H:%M:%S"
+  root:
+    level: DEBUG
+  loggers:
+    wayback_discover_diff.web:
+      handlers: [console]
+	  level: DEBUG
+    wayback_discover_diff.worker:
+      handlers: [console]
+	  level: DEBUG

--- a/wayback_discover_diff/discover.py
+++ b/wayback_discover_diff/discover.py
@@ -98,7 +98,7 @@ class Discover(Task):
         self.tpool = ThreadPoolExecutor(max_workers=cfg['threads'])
         self.snapshots_number = cfg['snapshots']['number_per_year']
         # Initialize logger
-        self._log = logging.getLogger(__name__)
+        self._log = logging.getLogger('wayback_discover_diff.worker')
 
     def download_capture(self, ts):
         """Download capture from WBM and update job status.

--- a/wayback_discover_diff/util.py
+++ b/wayback_discover_diff/util.py
@@ -62,6 +62,7 @@ def year_simhash(redis_db, url, year, page=None, snapshots_per_page=None):
                 if timestamps_to_fetch:
                     return handle_results(redis_db, timestamps_to_fetch, url,
                                           snapshots_per_page, page)
+            # TODO return empty result and NOT error.
             return {'status': 'error', 'message': 'NOT_CAPTURED'}
     except RedisError as exc:
         logging.error('error loading simhash data for url %s year %s page %d (%s)',


### PR DESCRIPTION
Define loggers `web_monitoring_processing.web` and
`web_monitoring_processing.worker`.

Load all logging conf from YAML.

Define logging conf example.

Remove unnecessary dependency on gunicorn.