### PR TITLE
Handle CDX query param encoding properly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='wayback-discover-diff',
-    version='0.1.6.12',
+    version='0.1.6.13',
     description='Calculate wayback machine captures simhash',
     packages=find_packages(),
     zip_safe=False,


### PR DESCRIPTION
Use `urllib3` auto request param encoding.

Use `werkzeug.urls.url_fix` to encode target URL properly when
downloading captures.