### PR TITLE
fit simhash to bytes convert to specified size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ htmlcov/
 dist/
 build/
 *.egg-info/
+.eggs

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -2,7 +2,7 @@
 import mock
 from test_util import StubRedis
 from wayback_discover_diff.discover import (extract_html_features,
-    calculate_simhash, Discover)
+    calculate_simhash, pack_simhash_to_bytes, Discover)
 
 
 def test_extract_html_features():
@@ -98,3 +98,66 @@ def test_worker_download(Redis):
     # redirects work fine.
     task.url = 'http://era.artiste.universalmusic.fr/'
     assert task.download_capture('20180716140623')
+
+
+def test_regular_hash():
+    features = {
+        '2019': 1,
+        'advanced': 1,
+        'google': 1,
+        'google©': 1,
+        'history': 1,
+        'insearch': 1,
+        'more': 1,
+        'optionssign': 1,
+        'privacy': 1,
+        'programsbusiness': 1,
+        'searchimagesmapsplayyoutubenewsgmaildrivemorecalendartranslatemobilebooksshoppingbloggerfinancephotosvideosdocseven': 1,
+        'searchlanguage': 1,
+        'settingsweb': 1,
+        'solutionsabout': 1,
+        'terms': 1,
+        'toolsadvertising': 1,
+        '»account': 1
+    }
+    h = calculate_simhash(features, 128)
+    assert h.bit_length() == 128
+    h_bytes = pack_simhash_to_bytes(h)
+    assert len(h_bytes) == 16
+
+
+def test_shortened_hash():
+    h_size = 128
+    features = {
+        'about': 1,
+        'accountsearchmapsyoutubeplaynewsgmailcontactsdrivecalendartranslatephotosshoppingmorefinancedocsbooksbloggerhangoutskeepjamboardearthcollectionseven': 1,
+        'at': 1,
+        'data': 1,
+        'feedbackadvertisingbusiness': 1,
+        'from': 1,
+        'gmailimagessign': 1,
+        'google': 3,
+        'helpsend': 1,
+        'in': 2,
+        'inappropriate': 1,
+        'library': 1,
+        'local': 1,
+        'more': 1,
+        'new': 1,
+        'predictions': 1,
+        'privacytermssettingssearch': 1,
+        'remove': 1,
+        'report': 1,
+        'searchhistorysearch': 1,
+        'searchyour': 1,
+        'settingsadvanced': 1,
+        'skills': 1,
+        'store': 1,
+        'with': 1,
+        'your': 1,
+        '×develop': 1
+    }
+    h = calculate_simhash(features, h_size)
+    assert h.bit_length() != h_size
+    h_bytes = pack_simhash_to_bytes(h, h_size)
+    assert len(h_bytes) == h_size // 8

--- a/wayback_discover_diff/discover.py
+++ b/wayback_discover_diff/discover.py
@@ -63,9 +63,12 @@ def calculate_simhash(features_dict, simhash_size):
     return Simhash(features_dict, simhash_size).value
 
 
-def pack_simhash_to_bytes(simhash):
+def pack_simhash_to_bytes(simhash, simhash_size=None):
     # simhash_value = simhash.value
-    size_in_bytes = (simhash.bit_length() + 7) // 8
+    if simhash_size is None:
+        size_in_bytes = (simhash.bit_length() + 7) // 8
+    else:
+        size_in_bytes = simhash_size // 8
     return simhash.to_bytes(size_in_bytes, byteorder='little')
 
 
@@ -203,7 +206,7 @@ class Discover(Task):
                 if cap[1] not in self.seen:
                     self.seen[cap[1]] = simhash
                 # This encoding is necessary to store simhash data in Redis.
-                final_results[cap[0]] = base64.b64encode(pack_simhash_to_bytes(simhash))
+                final_results[cap[0]] = base64.b64encode(pack_simhash_to_bytes(simhash, self.simhash_size))
             if i % 10 == 0:
                 self.update_state(
                     task_id=self.job_id, state='PENDING',


### PR DESCRIPTION
Fix extends hash bytes to fit desired bits size. In some cases we can get symhash shorter because of not positive values `v[i]` https://github.com/leonsim/simhash/blob/master/simhash/__init__.py#L110 and if when it happens at the end of feature space we will lost zeroes there.

Example:
request https://gext-api.archive.org/services/simhash/simhash?year=2019&url=google.com&compress=1
will return hashes with various size:

```
40: "x0pX7ccMGzLdKpj7T2zAjw=="
41: "x/hWqR8MGbJtKhjdD1pijQ=="
42: "/u8IyGqkURNg7x2ZNQOs"
43: "/M4Qy12NYTFgoyFJbA+8Cw=="
44: "wn1cq6cMEaApKhLzS0tq5Q=="
45: "+vkpxXpoiTMnzFMotsGCyA=="
```