### PR TITLE
Feature/allow bigger simhash size

### DIFF
--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -2,7 +2,7 @@
 import mock
 from test_util import StubRedis
 from wayback_discover_diff.discover import (extract_html_features,
-    calculate_simhash, pack_simhash_to_bytes, Discover)
+    calculate_simhash, custom_hash_function, pack_simhash_to_bytes, Discover)
 
 
 def test_extract_html_features():
@@ -159,5 +159,40 @@ def test_shortened_hash():
     }
     h = calculate_simhash(features, h_size)
     assert h.bit_length() != h_size
+    h_bytes = pack_simhash_to_bytes(h, h_size)
+    assert len(h_bytes) == h_size // 8
+
+
+def test_simhash_256():
+    h_size = 256
+    features = {
+        '2019': 1,
+        'advanced': 1,
+        'at': 1,
+        'google': 1,
+        'googleadvertising': 1,
+        'google©': 1,
+        'history': 1,
+        'insearch': 1,
+        'library': 1,
+        'local': 1,
+        'more': 1,
+        'new': 1,
+        'optionssign': 1,
+        'privacy': 1,
+        'programsbusiness': 1,
+        'searchimagesmapsplayyoutubenewsgmaildrivemorecalendartranslatemobilebooksshoppingbloggerfinancephotosvideosdocseven': 1,
+        'searchlanguage': 1,
+        'settingsweb': 1,
+        'skills': 1,
+        'solutionsabout': 1,
+        'terms': 1,
+        'toolsdevelop': 1,
+        'with': 1,
+        'your': 1,
+        '»account': 1,
+    }
+    h = calculate_simhash(features, h_size, custom_hash_function)
+    assert h.bit_length() == h_size
     h_bytes = pack_simhash_to_bytes(h, h_size)
     assert len(h_bytes) == h_size // 8

--- a/wayback_discover_diff/discover.py
+++ b/wayback_discover_diff/discover.py
@@ -1,4 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
+import hashlib
 import logging
 import string
 from datetime import datetime
@@ -56,11 +57,15 @@ def extract_html_features(html):
 #     return int(xxhash.xxh64(x).hexdigest(), 16)
 
 
-def calculate_simhash(features_dict, simhash_size):
+def custom_hash_function(x):
+    return int.from_bytes(hashlib.blake2b(x).digest(), byteorder='big')
+
+
+def calculate_simhash(features_dict, simhash_size, hashfunc=None):
     """Calculate simhash for features in a dict. `features_dict` contains data
     like {'text': weight}
     """
-    return Simhash(features_dict, simhash_size).value
+    return Simhash(features_dict, simhash_size, hashfunc=hashfunc).value
 
 
 def pack_simhash_to_bytes(simhash, simhash_size=None):
@@ -138,7 +143,7 @@ class Discover(Task):
             data = extract_html_features(response_data)
             if data:
                 self._log.info("calculating simhash")
-                return calculate_simhash(data, self.simhash_size)
+                return calculate_simhash(data, self.simhash_size, hashfunc=custom_hash_function)
         return None
 
     def run(self, url, year):

--- a/wayback_discover_diff/discover.py
+++ b/wayback_discover_diff/discover.py
@@ -87,6 +87,8 @@ class Discover(Task):
     def __init__(self, cfg):
         self.simhash_size = cfg['simhash']['size']
         self.simhash_expire = cfg['simhash']['expire_after']
+        if self.simhash_size > 512:
+            raise Exception('do not support simhash longer than 512')
 
         headers = {'User-Agent': 'wayback-discover-diff',
                    'Accept-Encoding': 'gzip,deflate',


### PR DESCRIPTION
because Simhash uses md5 by default which has 128b size we can't use simhash longer than 128bits. To be able to use longer simhash we should use base hash functions with bigger size (e.g. black2d gives 512bit)